### PR TITLE
Removed redundant $alternate_base_url switching

### DIFF
--- a/code/model/FilesystemPublisher.php
+++ b/code/model/FilesystemPublisher.php
@@ -147,7 +147,7 @@ class FilesystemPublisher extends DataExtension {
 
 			if (Config::inst()->get('FilesystemPublisher', 'domain_based_caching')) {
 				if (!$urlParts) continue; // seriously malformed url here...
-				$filename = $urlParts['host'] . '/' . $filename;
+				if (isset($urlParts['host'])) $filename = $urlParts['host'] . '/' . $filename;
 			}
 		
 			$mappedUrls[$url] = ((dirname($filename) == '/') ? '' :  (dirname($filename).'/')).basename($filename);

--- a/code/model/FilesystemPublisher.php
+++ b/code/model/FilesystemPublisher.php
@@ -194,10 +194,6 @@ class FilesystemPublisher extends DataExtension {
 		$currentBaseURL = Director::baseURL();
 		$staticBaseUrl = Config::inst()->get('FilesystemPublisher', 'static_base_url');
 		
-		if($staticBaseUrl) {
-			Config::inst()->update('Director', 'alternate_base_url', $staticBaseUrl);
-		}
-		
 		if($this->fileExtension == 'php') {
 			Config::inst()->update('SSViewer', 'rewrite_hash_links', 'php'); 
 		}
@@ -217,10 +213,6 @@ class FilesystemPublisher extends DataExtension {
 				'redirect' => null, 
 				'path' => null
 			);
-			
-			if($staticBaseUrl) {
-				Config::inst()->update('Director', 'alternate_base_url', $staticBaseUrl);
-			}
 
 			$i++;
 
@@ -342,10 +334,6 @@ class FilesystemPublisher extends DataExtension {
 					$missingFiles[$external] = true;
 				}
 			}*/
-		}
-
-		if(Config::inst()->get('FilesystemPublisher', 'static_base_url')) {
-			Config::inst()->update('Director', 'alternate_base_url', $currentBaseURL); 
 		}
 
 		if($this->fileExtension == 'php') {


### PR DESCRIPTION
The `$alternate_base_url` switching code below doesn't seem to serve a purpose. I'm sure it was probably put there for a reason so please correct me if I'm wrong - but I couldn't find any positive impact it had on the generated cache files. It does however have some negative impacts:

* causes all links in the generated page to become absolute, which is not necessary because of the included base tag, and also makes it inconsistent with the live site
* documentation states that `FilesystemPublisher::$static_base_url` must not include a trailing slash, but omitting this in combination with the absolute link conversion causes all paths to assets to be broken (e.g. mysite.comthemes/css/etc.)
* causes some mangling of links that point to pages on other subsites

Fixes #15