### PR TITLE
Uses a hash of the url for db locking to avoid errors on long urls

### DIFF
--- a/code/model/StaticPagesQueue.php
+++ b/code/model/StaticPagesQueue.php
@@ -171,7 +171,7 @@ class StaticPagesQueue extends DataObject {
 					do {
 						$queueObject = $filteredQuery->limit(1, $offset)->first();   //get first item
 
-						if ($queueObject) $lockName = $queueObject->URLSegment . $className;
+						if ($queueObject) $lockName = md5($queueObject->URLSegment . $className);
 						//try to locking the item's URL, keep trying new URLs until we find one that is free to lock
 						$offset++;
 					} while($queueObject && !LockMySQL::isFreeToLock($lockName));


### PR DESCRIPTION
The current implementation uses the entire url of a page plus a few GET variables as the lock name. For deeply nested pages with long URLs (which is not ideal, but occasionally happens) the "SELECT IS_FREE_LOCK" query fails with an error that the identifier name is too long.

This PR uses an MD5 hash of the same (url + get variables) to normalize the length of the lock id string.