### PR TITLE
Added URLArrayObject::sanitizeUrl()

### DIFF
--- a/code/model/FilesystemPublisher.php
+++ b/code/model/FilesystemPublisher.php
@@ -194,9 +194,9 @@ class FilesystemPublisher extends DataExtension {
 		$currentBaseURL = Director::baseURL();
 		$staticBaseUrl = Config::inst()->get('FilesystemPublisher', 'static_base_url');
 
-		// if($this->fileExtension == 'php') {
-		// 	Config::inst()->update('SSViewer', 'rewrite_hash_links', 'php');
-		// }
+		if($this->fileExtension == 'php') {
+			Config::inst()->update('SSViewer', 'rewrite_hash_links', 'php');
+		}
 
 		if(Config::inst()->get('FilesystemPublisher', 'echo_progress')) {
 			echo $this->class.": Publishing to " . $staticBaseUrl . "\n";
@@ -230,7 +230,8 @@ class FilesystemPublisher extends DataExtension {
 
 			if($url == "") $url = "/";
 			if(Director::is_relative_url($url)) $url = Director::absoluteURL($url);
-			$response = Director::test(str_replace('+', ' ', $url));
+			$sanitizedURL = URLArrayObject::sanitizeUrl($url);
+			$response = Director::test(str_replace('+', ' ', $sanitizedURL));
 
 			if (!$response) continue;
 
@@ -336,9 +337,9 @@ class FilesystemPublisher extends DataExtension {
 			}*/
 		}
 
-		// if($this->fileExtension == 'php') {
-		// 	Config::inst()->update('SSViewer', 'rewrite_hash_links', true);
-		// }
+		if($this->fileExtension == 'php') {
+			Config::inst()->update('SSViewer', 'rewrite_hash_links', true);
+		}
 
 		$base = BASE_PATH . "/$this->destFolder";
 

--- a/code/model/URLArrayObject.php
+++ b/code/model/URLArrayObject.php
@@ -81,13 +81,13 @@ class URLArrayObject extends ArrayObject {
 	/**
 	 * The format of the urls should be array( 'URLSegment' => '50')
 	 *
-	 * @param array $urls 
+	 * @param array $urls
 	 */
 	public function addUrls(array $urls) {
 		if(!$urls) {
 			return;
 		}
-		
+
 		$urlsAlreadyProcessed = array();    //array to filter out any duplicates
 		foreach ($urls as $URLSegment=>$priority) {
 			if(is_numeric($URLSegment) && is_string($priority)) {   //case when we have a non-associative flat array
@@ -147,10 +147,10 @@ class URLArrayObject extends ArrayObject {
 	}
 
 	/**
-	 * This method will insert all URLs that exists in this object into the 
+	 * This method will insert all URLs that exists in this object into the
 	 * database by calling the StaticPagesQueue
 	 *
-	 * @return type 
+	 * @return type
 	 */
 	public function insertIntoDB() {
 		$arraycopy = $this->getArrayCopy();
@@ -176,4 +176,12 @@ class URLArrayObject extends ArrayObject {
 		return ($a[0] > $b[0]) ? -1 : 1;
 	}
 
+	// removes the injected _ID and _ClassName get parameters
+	public static function sanitizeUrl($url) {
+		list($urlPart, $query) = array_pad(explode('?', $url), 2, '');
+		parse_str($query, $getVars);
+		unset($getVars['_ID'], $getVars['_ClassName']);
+		$sanitizedQuery = http_build_query($getVars);
+		return $urlPart . '?' . $sanitizedQuery;
+	}
 }


### PR DESCRIPTION
This is to remove the injected _ID and _ClassName which would otherwise appear in links when a SSL redirect url is generated or rewriteHashLink is called.