### PR TITLE
FIX: Preventing blank static cache files from being written.

### DIFF
--- a/code/model/FilesystemPublisher.php
+++ b/code/model/FilesystemPublisher.php
@@ -233,6 +233,12 @@ class FilesystemPublisher extends DataExtension {
 			$sanitizedURL = URLArrayObject::sanitize_url($url);
 			$response = Director::test(str_replace('+', ' ', $sanitizedURL));
 
+			// Prevent empty static cache files from being written
+			if (is_object($response) && !$response->getBody()) {
+				SS_Log::log(new Exception('Prevented blank static cache page write for: ' . $path), SS_Log::NOTICE);
+				continue;
+			}
+
 			if (!$response) continue;
 
 			if($response) {


### PR DESCRIPTION
Prevent static cache files from being written when the body is empty, this seems to happen occasionally when template files cannot be found by SSViewer. Note: this is only skipping writing the main cache file and does not treat the stale cache file at all.