### PR TITLE
Fix sanitize for lagging ? for empty query string

### DIFF
--- a/code/model/URLArrayObject.php
+++ b/code/model/URLArrayObject.php
@@ -182,6 +182,8 @@ class URLArrayObject extends ArrayObject {
 		parse_str($query, $getVars);
 		unset($getVars['_ID'], $getVars['_ClassName']);
 		$sanitizedQuery = http_build_query($getVars);
-		return $urlPart . '?' . $sanitizedQuery;
+		
+		$sanitizedQuery = ($sanitizedQuery !== '') ? '?' . $sanitizedQuery : '';
+		return $urlPart . $sanitizedQuery;
 	}
 }


### PR DESCRIPTION
This stops adding the ? to the url if the query string is empty