### PR TITLE
Added Option to disable MySQL row-level locking

### DIFF
--- a/code/model/StaticPagesQueue.php
+++ b/code/model/StaticPagesQueue.php
@@ -56,6 +56,12 @@ class StaticPagesQueue extends DataObject {
 	 *
 	 * @var boolean
 	 */
+	private static $use_mysql_locks = true;
+
+	/**
+	 *
+	 * @var boolean
+	 */
 	private static $realtime = false;
 
 	/**
@@ -166,7 +172,7 @@ class StaticPagesQueue extends DataObject {
 			$filteredQuery = $query->filter($filterQuery)->sort($sortOrder);
 
 			if ($filteredQuery->Count() > 0) {
-				if (DB::getConn() instanceof MySQLDatabase) {   //locking currently only works on MySQL
+				if (self::config()->use_mysql_locks && DB::getConn() instanceof MySQLDatabase) {   //locking currently only works on MySQL
 
 					do {
 						$queueObject = $filteredQuery->limit(1, $offset)->first();   //get first item


### PR DESCRIPTION
Galera Cluster does not support table locking, as they conflict with multi-master replication. If Staticpublishqueue is used in a clustered setup, the lock requests crash the underlying database nodes.

This adds a new configuration option (use_mysql_locks) to control the use of MySQL Locks. By default they are enabled (on MySQL based backends).

To disable row locks add the following to your configuration:
```yml
StaticPagesQueue:
  use_mysql_locks: false
```