### PR TITLE
Added Option to disable MySQL row-level locking

### DIFF
--- a/code/model/StaticPagesQueue.php
+++ b/code/model/StaticPagesQueue.php
@@ -56,6 +56,12 @@ class StaticPagesQueue extends DataObject {
 	 *
 	 * @var boolean
 	 */
+	private static $disable_mysql_locks = false;
+
+	/**
+	 *
+	 * @var boolean
+	 */
 	private static $realtime = false;
 
 	/**
@@ -166,7 +172,7 @@ class StaticPagesQueue extends DataObject {
 			$filteredQuery = $query->filter($filterQuery)->sort($sortOrder);
 
 			if ($filteredQuery->Count() > 0) {
-				if (DB::getConn() instanceof MySQLDatabase) {   //locking currently only works on MySQL
+				if (!self::config()->disable_mysql_locks && DB::getConn() instanceof MySQLDatabase) {   //locking currently only works on MySQL
 
 					do {
 						$queueObject = $filteredQuery->limit(1, $offset)->first();   //get first item


### PR DESCRIPTION
Galera Cluster does not support table locking, as they conflict with multi-master replication. If Staticpublishqueue is used in a clustered setup, the lock requests crash the underlying database nodes.

This adds a new configuration option (disable_mysql_locks) to control the use of MySQL Locks. By default they are enabled (on MySQL based backends).

To disable row locks add the following to your configuration:
```yml
StaticPagesQueue:
  disable_mysql_locks: true
```

@dhensby this is an alternate version of #54 
Tested on 3.1.16
Tests:
1. No setting in yml: MySQL Locks will be used
2. Setting disable_mysql_locks to **false** in yml: MySQL Locks will be used
3. Setting disable_mysql_locks to **true** in yml: MySQL Locks **not** will be used