### PR TITLE
FIX: PurgeObseleteStaticCacheTask shouldn't clear out index.php

### DIFF
--- a/code/tasks/PurgeObseleteStaticCacheTask.php
+++ b/code/tasks/PurgeObseleteStaticCacheTask.php
@@ -73,7 +73,7 @@ class PurgeObseleteStaticCacheTask extends BuildTask {
 			}
 
 			// Handle homepage special case
-			if($file_relative == 'index.html') $urlpath = '';
+			if($file_relative == 'index.html' || $file_relative == 'index.php') $urlpath = '';
 
 			// Exclude files that do not end in the file extension specified for FilesystemPublisher
 			$length = strlen('.' . $fileext);


### PR DESCRIPTION
`PurgeObseleteStaticCacheTask` currently has a special case fix for the website homepage to ensure it never deletes that file. However, this doesn't work if the website uses `index.php` to identify the homepage.

I'm not sure if we could use `$fileext` here to be more generic, there's some special magic here around the stale files that I didn't want to mess with.